### PR TITLE
Updated extension to work on Gnome-shell 40

### DIFF
--- a/transparentosd@ipaq3870/metadata.json
+++ b/transparentosd@ipaq3870/metadata.json
@@ -4,7 +4,8 @@
   "name": "Transparent OSD",
   "shell-version": [
     "3.18",
-    "3.20"
+    "3.20",
+    "40.0"
   ],
   "url": "https://github.com/ipaq3870/gsext-transparent-osd",
   "uuid": "transparentosd@ipaq3870",


### PR DESCRIPTION
included Gnome-shell 40 in metadata